### PR TITLE
Addition of new constraints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ else()
     FetchContent_Declare(
       xcsp3parser
       GIT_REPOSITORY    "https://github.com/xcsp3team/XCSP3-CPP-Parser"
-      GIT_TAG           50ee7bfa59327c31a0a66ca4072a23cd08d0b182
+      GIT_TAG           ebed5a8759eecae79128dddc0e7e10f96cebe9bb
     )
   endif()
 


### PR DESCRIPTION
This PR adds the following constraints :
- sum
   -  `void buildConstraintSum(string id, vector<XVariable *> &list, vector<int> &coeffs, XCondition &cond) `
   -   `void buildConstraintSum(string id, vector<XVariable *> &list, XCondition &cond) `
- element 
  - `void buildConstraintElement(string id, vector<XVariable *> &list, int value)`
  - `void buildConstraintElement(string id, vector<XVariable *> &list, XVariable *value)`
  - `void buildConstraintElement(string id, vector<XVariable *> &list, XVariable *index, int startIndex, XCondition &xc)`
   - `void buildConstraintElement(string id, vector<XVariable *> &list, int startIndex, XVariable *index, RankType rank, int value)`
   - `void buildConstraintElement(string id, vector<XVariable *> &list, int startIndex, XVariable *index, RankType rank, XVariable *value)`
    - `void buildConstraintElement(string id, vector<int> &list, int startIndex, XVariable *index, RankType rank, XVariable *value)`
     - `void buildConstraintElement(string id, vector<vector<int> > &matrix, int startRowIndex, XVariable *rowIndex, int startColIndex, XVariable* colIndex, XVariable *value)`
- extension (one only) :
    - `void buildConstraintExtension(string id, vector<XVariable *> list, vector<vector<int>> &tuples, bool support, bool hasStar)`  