### PR TITLE
Ubuntu needs #include <cinttypes>

### DIFF
--- a/include/lala/flatzinc_parser.hpp
+++ b/include/lala/flatzinc_parser.hpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <cfenv>
 #include <set>
+#include <cinttypes>
 
 #include "battery/shared_ptr.hpp"
 #include "lala/logic/ast.hpp"


### PR DESCRIPTION
Ubuntu needs to specify the header `cinttypes` for `PRIu64`. 