### PR TITLE
Fix auxiliary variable domain in constraint decomposition to prevent incorrect UNSAT results

### DIFF
--- a/include/lala/XCSP3_parser.hpp
+++ b/include/lala/XCSP3_parser.hpp
@@ -480,7 +480,7 @@ void XCSP3_turbo_callbacks<Allocator>::buildConstraintExtension(string id, vecto
   lala::Sig sig = support ? lala::EQ : lala::NEQ;
   if (table_decomposition == lala::TableDecomposition::ELEMENTS && support) {
     size_t numVars = tuples[0].size();
-    auto auxVar = F::make_lvar(UNTYPED, buildAuxVariableInteger(numVars - 1));
+    auto auxVar = F::make_lvar(UNTYPED, buildAuxVariableInteger(tuples.size() -1));
     for (int i = 0; i < numVars; ++i) {
       for (int j = 0; j < tuples.size(); ++j) {
         // index = i ==> varName = value

--- a/include/lala/solver_output.hpp
+++ b/include/lala/solver_output.hpp
@@ -4,6 +4,9 @@
 
 #ifndef OUTPUT_H
 #define OUTPUT_H
+#include <functional>
+#include <peglib.h>
+#include <lala/logic/ast.hpp>
 
 
 namespace lala {


### PR DESCRIPTION
This PR fixes a bug related to the domain of the auxiliary variable (`auxVar`) in the decomposition of constraints into element constraints. Previously, the domain of the auxiliary variable was incorrectly calculated based on the number of variables (`numVars`), which could result in the solver returning `UNSAT` for an instance that is actually `SAT`. This was due to the auxiliary variable having an incorrect domain size, leading to inconsistencies in the solution process.